### PR TITLE
Downgrade requirement to python 3.6

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,20 @@
 
 import setuptools
 
+
 def get_requirements():
     reqs = []
     for line in open('requirements.txt', 'r').readlines():
         reqs.append(line)
     return reqs
 
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="seiqrdp_model", 
-    version="7.5.2",
+    name="seiqrdp_model",
+    version="7.5.3",
     author="T.Rouabah, N.Belaloui, A.Tounsi",
     author_email="m.t.rouabah@gmail.com",
     description="Computational tools to fit data, simulate and calibrate\
@@ -26,6 +28,6 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     install_requires=get_requirements()
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     author="T.Rouabah, N.Belaloui, A.Tounsi",
     author_email="m.t.rouabah@gmail.com",
     description="Computational tools to fit data, simulate and calibrate\
-    parameters of the compartmental epiddmiological SEIQRDP model.",
+    parameters of the compartmental epidemiological SEIQRDP model.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Taha-Rouabah/COVID-19",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="seiqrdp_model", 
-    version="7.5",
+    version="7.5.1",
     author="T.Rouabah, N.Belaloui, A.Tounsi",
     author_email="m.t.rouabah@gmail.com",
     description="Computational tools to fit data, simulate and calibrate\

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="seiqrdp_model", 
-    version="7.5.1",
+    version="7.5.2",
     author="T.Rouabah, N.Belaloui, A.Tounsi",
     author_email="m.t.rouabah@gmail.com",
     description="Computational tools to fit data, simulate and calibrate\


### PR DESCRIPTION
Conda tests runs on python 3.6.10: [here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=175522&view=logs&jobId=10bda42a-d420-5c28-a43f-bc4e66405e5c)

> pip._internal.exceptions.UnsupportedPythonVersion: Package 'seiqrdp-model' requires a different Python: 3.6.10 not in '>=3.7'

* I have downgrade the python requirement to **3.6+**
* Added the `requirement.txt` and `LICENSE` to the source distribution.

And I have tested it on python 3.6.10, the launcher worked perfectly.